### PR TITLE
fix: add trainer/path into middleware config

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,5 +14,6 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-    matcher: ['/api/:path*', '/auth/:path*'],
+    matcher: ['/api/:path*', '/auth/:path*', '/trainer/:path*'],
+
 }


### PR DESCRIPTION

add : /trainer/:path* into config to connect routes
